### PR TITLE
Automatic Rebirth Requests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/neuron",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Neuron is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "GPL-3.0-or-later",

--- a/stateMachines/host.test.ts
+++ b/stateMachines/host.test.ts
@@ -83,7 +83,40 @@ describe("The host state machine", () => {
     });
   });
 
-  it("disconnects properly when we tell it to", async () => {
+  it("stores the groupId and nodeId of nbirth messages", async () => {
+    host.events.emit(
+      "nbirth",
+      { groupId: "testGroup", edgeNode: "testNode" },
+      {
+        metrics: [{ name: "testMetric", type: "testType", value: "testValue" }],
+      },
+    );
+    expect(host.groups["testGroup"]).toBeDefined();
+    expect(host.groups["testGroup"].nodes["testNode"]).toBeDefined();
+    expect(
+      host.groups["testGroup"].nodes["testNode"].metrics["testMetric"],
+    ).toBeDefined();
+  });
+
+  it("stores the deviceId of dbirth messages", async () => {
+    host.events.emit(
+      "dbirth",
+      { groupId: "testGroup", edgeNode: "testNode", deviceId: "testDevice" },
+      {
+        metrics: [{ name: "testMetric", type: "testType", value: "testValue" }],
+      },
+    );
+    expect(host.groups["testGroup"]).toBeDefined();
+    expect(host.groups["testGroup"].nodes["testNode"]).toBeDefined();
+    expect(host.groups["testGroup"].nodes["testNode"].devices["testDevice"])
+      .toBeDefined();
+    expect(
+      host.groups["testGroup"].nodes["testNode"].devices["testDevice"]
+        .metrics["testMetric"],
+    ).toBeDefined();
+  });
+
+  it("disconnects properly when we tell it to", () => {
     const mockOnDisconnect = spy();
     host.events.on("disconnected", mockOnDisconnect);
     disconnectHost(host);

--- a/stateMachines/node.test.ts
+++ b/stateMachines/node.test.ts
@@ -1,12 +1,24 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { createNode, disconnectNode } from "./node.ts";
-import type { SparkplugCreateNodeInput, SparkplugNode } from "../types.d.ts";
+import {
+  createNode,
+  disconnectNode,
+  metricNeedsToPublish,
+  nodeTransitions,
+} from "./node.ts";
+import type {
+  SparkplugCreateNodeInput,
+  SparkplugMetric,
+  SparkplugNode,
+} from "../types.d.ts";
 import type { IDisconnectPacket, MqttClient } from "mqtt";
 import type mqtt from "mqtt";
-import { assertSpyCalls, spy, stub } from "@std/testing/mock";
+import { assertSpyCalls, Spy, spy, stub } from "@std/testing/mock";
 import { EventEmitter } from "node:events";
 import { _internals } from "../mqtt.ts";
+import { Buffer } from "node:buffer";
+import { encodePayload } from "../mqtt.ts";
+import { getUnixTime } from "date-fns";
 
 const connectPacket: mqtt.IConnackPacket = {
   cmd: "connack",
@@ -17,6 +29,12 @@ const connectPacket: mqtt.IConnackPacket = {
 const disconnectPacket: IDisconnectPacket = {
   cmd: "disconnect",
 };
+
+stub(console, "debug");
+stub(console, "info");
+stub(console, "error");
+const warnStub = stub(console, "warn");
+// stub(console, "log");
 
 describe("Node", () => {
   const mockConfig: SparkplugCreateNodeInput = {
@@ -41,17 +59,13 @@ describe("Node", () => {
             name: "testMetric",
             type: "String",
             value: "testValue",
+            scanRate: 1000,
           },
         },
       },
     },
   };
   let node: SparkplugNode;
-  stub(console, "debug");
-  stub(console, "info");
-  stub(console, "error");
-  stub(console, "warn");
-  stub(console, "log");
   it("creates a node with correct properties", () => {
     const mockClient = new EventEmitter() as unknown as mqtt.MqttClient;
     mockClient.subscribe = spy() as typeof MqttClient.prototype.subscribe;
@@ -116,6 +130,56 @@ describe("Node", () => {
         dead: false,
       },
       disconnected: false,
+    });
+  });
+  describe("birth transition", () => {
+    it("publishes a birth message if the mqtt client exists.", () => {
+      const calls = (node.mqtt?.publish as Spy).calls.length;
+      nodeTransitions.birth(node);
+      expect(node.mqtt?.publish).toBeDefined();
+      if (node.mqtt?.publish) {
+        assertSpyCalls(node.mqtt.publish as Spy, calls + 1);
+      }
+    });
+    it("publishes nothing if the mqtt client doesn't exist.", () => {
+      nodeTransitions.birth({} as SparkplugNode);
+      assertSpyCalls(warnStub, 1);
+    });
+  });
+  describe("Report By Exception", () => {
+    it("is true if lastPublished value is null", () => {
+      const testMetric: SparkplugMetric = {
+        name: "testMetric",
+        type: "Int32",
+        value: 101,
+        deadband: {
+          value: 100,
+          maxTime: 1000,
+        },
+        lastPublished: {
+          timestamp: getUnixTime(new Date()),
+          value: null,
+        },
+        scanRate: 1000,
+      };
+      expect(metricNeedsToPublish(testMetric)).toBe(true);
+    });
+    it("is false if lastPublished value is not null", () => {
+      const testMetric: SparkplugMetric = {
+        name: "testMetric",
+        type: "Int32",
+        value: 101,
+        deadband: {
+          value: 100,
+          maxTime: 1000,
+        },
+        lastPublished: {
+          timestamp: getUnixTime(new Date()),
+          value: 100,
+        },
+        scanRate: 1000,
+      };
+      expect(metricNeedsToPublish(testMetric)).toBe(false);
     });
   });
   it("disconnects properly when we tell it to", async () => {

--- a/stateMachines/utils.ts
+++ b/stateMachines/utils.ts
@@ -3,10 +3,10 @@ import { log } from "../log.ts";
 import type { Buffer } from "node:buffer";
 
 import type {
-  SparkplugNode,
-  SparkplugHost,
   ISparkplugEdgeOptions,
   ISparkplugHostOptions,
+  SparkplugHost,
+  SparkplugNode,
 } from "../types.d.ts";
 import { handleMessage } from "../mqtt.ts";
 
@@ -19,7 +19,7 @@ import { handleMessage } from "../mqtt.ts";
 export const emit = (
   event: string,
   data: undefined | unknown,
-  emitter: EventEmitter
+  emitter: EventEmitter,
 ) => emitter.emit(event, data);
 
 /**
@@ -42,7 +42,7 @@ export const emitCurry =
 export const on = <T extends { on: (event: U, listener: V) => void }, U, V>(
   event: U,
   listener: V,
-  emitter: T
+  emitter: T,
 ): T => {
   log.debug(`on ${event} added`);
   emitter.on(event, listener);
@@ -58,10 +58,9 @@ export const on = <T extends { on: (event: U, listener: V) => void }, U, V>(
 export const onCurry =
   <T extends { on: (event: U, listener: V) => void }, U, V>(
     event: U,
-    listener: V
+    listener: V,
   ) =>
-  (emitter: T): T =>
-    on(event, listener, emitter);
+  (emitter: T): T => on(event, listener, emitter);
 
 /**
  * Retrieves the MQTT configuration from a Sparkplug Node or Host object.
@@ -81,13 +80,13 @@ export const onCurry =
  */
 
 export function getMqttConfigFromSparkplug(
-  input: SparkplugNode
+  input: SparkplugNode,
 ): ISparkplugEdgeOptions;
 export function getMqttConfigFromSparkplug(
-  input: SparkplugHost
+  input: SparkplugHost,
 ): ISparkplugHostOptions;
 export function getMqttConfigFromSparkplug(
-  input: SparkplugNode | SparkplugHost
+  input: SparkplugNode | SparkplugHost,
 ): ISparkplugEdgeOptions | ISparkplugHostOptions {
   const commonConfig = {
     clientId: input.clientId,
@@ -123,10 +122,9 @@ export function getMqttConfigFromSparkplug(
  */
 export const onMessage = (input: SparkplugNode | SparkplugHost) => {
   return (topic: string, message: Buffer) => {
-    const config =
-      "groupId" in input
-        ? getMqttConfigFromSparkplug(input as SparkplugNode)
-        : getMqttConfigFromSparkplug(input as SparkplugHost);
+    const config = "groupId" in input
+      ? getMqttConfigFromSparkplug(input as SparkplugNode)
+      : getMqttConfigFromSparkplug(input as SparkplugHost);
     handleMessage(topic, message, input.events, config);
   };
 };
@@ -149,4 +147,18 @@ export const flatten = <T>(obj: { [key: string]: T }) => {
     id: key,
     name: key,
   }));
+};
+
+export const unflatten = <T extends { name?: string | null }>(
+  arr?: T[] | null,
+): { [key: string]: T } => {
+  if (!arr) {
+    return {};
+  }
+  return arr.reduce((acc, item) => {
+    if (item.name) {
+      acc[item.name] = item;
+    }
+    return acc;
+  }, {} as { [key: string]: T });
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -46,6 +46,7 @@ export interface SparkplugCreateBaseInput {
   id: string;
   version?: string;
   keepalive?: number;
+  payloadOptions?: PayloadOptions;
   mqttOptions?: Omit<
     IClientOptions,
     | "clientId"
@@ -64,7 +65,6 @@ export interface SparkplugCreateNodeInput extends SparkplugCreateBaseInput {
   metrics: {
     [id: string]: SparkplugMetric;
   };
-  payloadOptions?: PayloadOptions;
   devices: {
     [id: string]: SparkplugCreateDeviceInput;
   };
@@ -90,6 +90,26 @@ export interface SparkplugCreateHostInput extends SparkplugCreateBaseInput {
 }
 export interface SparkplugHost extends SparkplugBase {
   primaryHostId: string;
+  groups: {
+    [groupId: string]: SparkplugGroup;
+  };
+}
+
+export interface SparkplugGroup {
+  nodes: {
+    [nodeId: string]: {
+      metrics: {
+        [metricId: string]: UMetric;
+      };
+      devices: {
+        [deviceId: string]: {
+          metrics: {
+            [metricId: string]: UMetric;
+          };
+        };
+      };
+    };
+  };
 }
 
 export interface SparkplugNode extends SparkplugCreateNodeInput {


### PR DESCRIPTION
Added to SparkplugHost the recording of all Sparkplug B Metrics into memory and also automatic rebirth requests based on whether the upstream entity has been birthed.

