### PR TITLE
fix: emit mqttError instead of error to prevent process crash

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.84",
+  "version": "0.0.85",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "GPL-3.0",

--- a/stateMachines/host.ts
+++ b/stateMachines/host.ts
@@ -97,7 +97,7 @@ export const onError = (host: SparkplugHost) => {
   return (error: Error) => {
     setHostStateDisconnected(host);
     log.error(error);
-    host.events.emit("error", error);
+    host.events.emit("mqttError", error);
   };
 };
 

--- a/stateMachines/types.ts
+++ b/stateMachines/types.ts
@@ -4,7 +4,7 @@ import type { UPayload } from "sparkplug-payload/lib/sparkplugbpayload.js";
 
 export type HostTransition = "connect" | "disconnect";
 
-export type HostEvent = "connect" | "disconnect" | "message";
+export type HostEvent = "connect" | "disconnect" | "message" | "mqttError";
 
 export type Listener =
   | ((topic: string, message: Buffer) => void)
@@ -14,6 +14,7 @@ export type NodeEvent =
   | "connect"
   | "disconnect"
   | "message"
+  | "mqttError"
   | "ncmd"
   | "dcmd"
   | "ddata"


### PR DESCRIPTION
## Summary
- Changed host.ts to emit "mqttError" event instead of "error" when MQTT errors occur
- The "error" event on Node.js EventEmitter crashes the process when unhandled, causing Mantle to enter CrashLoopBackOff on keepalive timeouts
- Updated HostEvent and NodeEvent types to include "mqttError"

## Test plan
- [ ] Verify Mantle no longer crashes on MQTT keepalive timeouts
- [ ] Verify mqttError events can be handled by subscribers

Generated with [Claude Code](https://claude.com/claude-code)