### PR TITLE
fix: re-subscribe to DCMD/NCMD/STATE on mqtt reconnect

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.84",
+  "version": "0.0.86",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "GPL-3.0",


### PR DESCRIPTION
## Summary
- Fix DCMD events not firing after mqtt.js auto-reconnects
- Add subscription logic to `onConnect()` to re-establish subscriptions on every connect

## Problem
When mqtt.js auto-reconnects after a connection drop (e.g., triggered by STATE message from primary application), the `onConnect` handler fired but didn't re-subscribe to command topics. Since `clean: true` is set, the broker forgets subscriptions on disconnect.

This caused DCMD events to stop firing after reconnection cycles, breaking bidirectional communication with PLCs via tentacle-mqtt.

## Solution
Add subscription logic to `onConnect()` so that DCMD, NCMD, and STATE subscriptions are re-established on every connect event, including auto-reconnects.

## Test plan
- [x] All existing tests pass
- [ ] Manual test: Send DCMD via Ignition/MQTTX after connection cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)