### PR TITLE
fix: preserve external event listeners during disconnect

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.86",
+  "version": "0.0.87",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "GPL-3.0",

--- a/stateMachines/node.ts
+++ b/stateMachines/node.ts
@@ -246,7 +246,8 @@ export const nodeTransitions = {
   disconnect: (node: SparkplugNode) => {
     killNode(node);
     destroyMqttClient(node.mqtt);
-    cleanUpEventListeners(node.events);
+    // Only remove internal "ncmd" listener, preserve external listeners (e.g., "dcmd")
+    node.events.removeAllListeners("ncmd");
     return setNodeStateDisconnected(node);
   },
   birth: async (node: SparkplugNode) => {


### PR DESCRIPTION
## Summary
- Only remove internal "ncmd" listener instead of all listeners when disconnecting
- This preserves external listeners like "dcmd" that users attach to the node.events emitter

## Problem
When the node transitions to disconnect state, `cleanUpEventListeners(node.events)` was removing ALL listeners. This caused external handlers (like dcmd) to be lost after MQTT reconnection cycles.

## Solution
Changed `cleanUpEventListeners(node.events)` to `node.events.removeAllListeners("ncmd")` to only remove the internal ncmd listener while preserving external listeners.

## Test plan
- [x] Existing tests pass
- [ ] Manual testing with tentacle-mqtt DCMD handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)