### PR TITLE
Fix DBIRTH and DDEATH MQTT subscriptions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.87",
+  "version": "0.0.88",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "GPL-3.0",

--- a/stateMachines/host.ts
+++ b/stateMachines/host.ts
@@ -141,14 +141,14 @@ const setupHostEvents = (host: SparkplugHost) => {
             host.sharedSubscriptionGroup,
           ),
           subscribeCurry(`${host.version}/+/NDEATH/+`, { qos: 0 }),
-          subscribeCurry(`${host.version}/+/DBIRTH/+`, { qos: 0 }),
+          subscribeCurry(`${host.version}/+/DBIRTH/#`, { qos: 0 }),
           subscribeCurry(`${host.version}/+/DCMD/+`, { qos: 0 }),
           subscribeCurry(
             `${host.version}/+/DDATA/#`,
             { qos: 0 },
             host.sharedSubscriptionGroup,
           ),
-          subscribeCurry(`${host.version}/+/DDEATH/+`, { qos: 0 }),
+          subscribeCurry(`${host.version}/+/DDEATH/#`, { qos: 0 }),
         ),
     );
     createHostMessageEvents(host);


### PR DESCRIPTION
## Summary
- DBIRTH and DDEATH topic subscriptions used single-level wildcard (`+`) which only matches 4-level topics
- Device births/deaths are 5 levels: `spBv1.0/{group}/DBIRTH/{node}/{device}`
- Changed to multi-level wildcard (`#`) so device-level messages are actually received
- This was causing Mantle hosts to miss all DBIRTH payloads, meaning only metrics from DDATA (changing values) appeared in the GUI instead of the full metric set from birth certificates

## Test plan
- [x] All existing tests pass (`deno test --allow-env`)
- [ ] Deploy updated Mantle with this synapse version and verify DBIRTH metrics appear

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>