### PR TITLE
Fix SPDX license for JSR publish

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,9 +1,9 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
-  "license": "GPL-3.0",
+  "license": "GPL-3.0-or-later",
   "repository": "github:joyautomation/synapse",
   "homepage": "https://github.com/joyautomation/synapse#readme",
   "bugs": "https://github.com/joyautomation/synapse/issues",


### PR DESCRIPTION
## Summary
- Fix deprecated `GPL-3.0` SPDX identifier to `GPL-3.0-or-later`
- JSR now enforces valid SPDX identifiers, blocking 0.0.88 publish
- Bumps version to 0.0.89

## Test plan
- [ ] JSR publish succeeds after tagging