### PR TITLE
Add try-catch to createCommandAction to prevent decode errors from blocking mqtt.js

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "Apache-2.0",

--- a/mqtt.ts
+++ b/mqtt.ts
@@ -624,12 +624,18 @@ const parseTopicMessage = (topic: SparkplugTopic) => {
 const createCommandAction =
   (key: string, emitter: EventEmitter) =>
   ({ topic, message }: SpbMessageConditionInput) => {
-    const decompressed = decompressPayload(message);
-    if (isBuffer(decompressed)) {
-      const decoded = decodePayload(decompressed);
-      emitter.emit(key.toLowerCase(), topic, decoded);
+    try {
+      const decompressed = decompressPayload(message);
+      if (isBuffer(decompressed)) {
+        const decoded = decodePayload(decompressed);
+        emitter.emit(key.toLowerCase(), topic, decoded);
+      }
+      log.debug(`${key} message received for ${parseTopicMessage(topic)}`);
+    } catch (error) {
+      log.error(
+        `Error processing ${key} message for ${parseTopicMessage(topic)}: ${error instanceof Error ? error.message : error}`
+      );
     }
-    log.debug(`${key} message received for ${parseTopicMessage(topic)}`);
   };
 
 /**


### PR DESCRIPTION
## Summary
- Wraps `createCommandAction` in try-catch to prevent `decodePayload()` errors from killing the entire MQTT packet processing pipeline
- The root cause: `sparkplug-payload@1.0.3` throws `Invalid DataSetValue` for DateTime columns in DataSet metrics during DBIRTH decode
- Without the catch, the error propagates through mqtt.js's `EventEmitter.emit('message')`, causing the writable stream `done()` callback to never fire, permanently blocking all subsequent packet processing (including PINGRESP → keepalive timeout)

## Root Cause
The `getDataSetValue()` function in sparkplug-payload only handles DataSet column types 4, 7, 9-12 but **not DateTime (type 13)**. When an edge device sends a DBIRTH with a DataSet metric containing a DateTime column (e.g., `{"longValue":"1594429272000"}`), the decoder throws.

## Test plan
- [x] All existing synapse tests pass (`deno test -A`)
- [x] Verified locally: with the catch in place, DBIRTH decode errors are logged but DDATA messages continue flowing normally
- [x] Without the catch, the MQTT connection dies after receiving one NBIRTH+DBIRTH

🤖 Generated with [Claude Code](https://claude.com/claude-code)