### PR TITLE
Switch to @joyautomation/sparkplug-payload fork

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "mqtt": "npm:mqtt@^5.10.1",
     "nanoid": "npm:nanoid@^5.1.0",
     "pako": "npm:pako@^2.1.0",
-    "sparkplug-payload": "npm:sparkplug-payload@1.0.3",
+    "sparkplug-payload": "npm:@joyautomation/sparkplug-payload@^1.0.4",
     "types": "npm:types@^0.1.1"
   },
   "nodeModulesDir": "auto",

--- a/mqtt.ts
+++ b/mqtt.ts
@@ -6,7 +6,7 @@ import type {
   SparkplugNode,
   SparkplugTopic,
 } from "./types.ts";
-import * as sparkplug from "npm:sparkplug-payload@1.0.3";
+import * as sparkplug from "sparkplug-payload";
 import { pipe } from "@joyautomation/dark-matter";
 import { logs } from "./log.ts";
 const { main: log } = logs;


### PR DESCRIPTION
## Summary
- Replace `sparkplug-payload@1.0.3` with `@joyautomation/sparkplug-payload@^1.0.4`
- Fixes `getDataSetValue()` missing type handlers (Int8/16/32, UInt8/16/64, DateTime, Text, UUID)
- This was the root cause of DBIRTH decode failures for payloads containing DataSet metrics with DateTime columns

## Test plan
- [x] All synapse tests pass locally
- [ ] CI passes