### PR TITLE
Add Sparkplug B template/UDT support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.92",
+  "version": "0.0.93",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "Apache-2.0",

--- a/index.ts
+++ b/index.ts
@@ -107,6 +107,32 @@ export { getNodeStateString } from "./stateMachines/node.ts";
 export { getHostStateString } from "./stateMachines/host.ts";
 
 /**
+ * Returns the template definitions registry for a host.
+ * Populated from NBIRTH metrics with isDefinition=true.
+ * @param {SparkplugHost} host - The SparkplugHost instance.
+ * @returns {Map<string, UTemplate>} Map of template name to definition.
+ */
+export { getTemplateDefinitions } from "./stateMachines/host.ts";
+
+/**
+ * Flattens template instance metrics into individual scalar metrics with path-based names.
+ * Template definitions (isDefinition=true) are skipped.
+ * @param {UMetric[]} metrics - The metrics array to flatten.
+ * @param {string} [parentPath] - Path prefix for nested templates.
+ * @param {string} [parentTemplateRef] - Template definition name.
+ * @param {string} [parentInstance] - Template instance name.
+ * @returns {UMetric[]} Flattened metrics with templateRef and templateInstance annotations.
+ */
+export { flattenTemplateMetrics } from "./stateMachines/host.ts";
+
+/**
+ * Extracts template definitions from metrics and stores them in the host registry.
+ * @param {SparkplugHost} host - The SparkplugHost instance.
+ * @param {UMetric[]} metrics - The metrics to scan for definitions.
+ */
+export { extractAndStoreDefinitions } from "./stateMachines/host.ts";
+
+/**
  * Adds metrics to a Sparkplug node or device, merging with existing metrics.
  * @param {SparkplugNode} node - The Sparkplug node to modify.
  * @param {Record<string, SparkplugMetric>} metrics - Record of metrics to add (will be merged with existing metrics).

--- a/types.ts
+++ b/types.ts
@@ -337,6 +337,10 @@ export interface SparkplugMetric extends Omit<UMetric, "value"> {
     timestamp: number;
     value: UMetric["value"];
   };
+  /** The name of the template definition this metric was flattened from (e.g., "Pump_Type"). */
+  templateRef?: string;
+  /** The name of the template instance this metric belongs to (e.g., "Pump1"). */
+  templateInstance?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Flattens Sparkplug B template instance metrics into individual scalar metrics with path-based names (e.g., `Pump1/temperature`)
- Each flattened metric annotated with `templateRef` and `templateInstance` fields for codegen/introspection
- Template definitions stored in per-host in-memory registry, accessible via `getTemplateDefinitions()`
- Flattening integrated into `createHostMessageEvents` so all downstream listeners (including Mantle) see flattened metrics automatically

## Test plan
- [x] Unit tests for `flattenTemplateMetrics` (regular metrics, instances, definitions, nested, partial updates, empty)
- [x] Unit tests for `extractAndStoreDefinitions`
- [x] Integration tests for template metrics in NBIRTH/NDATA events
- [x] All existing tests pass (`deno task test` — 9 passed, 51 steps, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)