### PR TITLE
Replace templateRef with templateChain for full UDT nesting context

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "Apache-2.0",

--- a/stateMachines/host.test.ts
+++ b/stateMachines/host.test.ts
@@ -231,17 +231,17 @@ describe("The host state machine", () => {
         },
       ];
       const result = flattenTemplateMetrics(metrics) as (UMetric & {
-        templateRef?: string;
+        templateChain?: string[];
         templateInstance?: string;
       })[];
       expect(result).toHaveLength(2);
       expect(result[0].name).toBe("Pump1/temperature");
       expect(result[0].type).toBe("Double");
       expect(result[0].value).toBe(72.5);
-      expect(result[0].templateRef).toBe("Pump_Type");
+      expect(result[0].templateChain).toEqual(["Pump_Type"]);
       expect(result[0].templateInstance).toBe("Pump1");
       expect(result[1].name).toBe("Pump1/pressure");
-      expect(result[1].templateRef).toBe("Pump_Type");
+      expect(result[1].templateChain).toEqual(["Pump_Type"]);
       expect(result[1].templateInstance).toBe("Pump1");
     });
 
@@ -314,15 +314,15 @@ describe("The host state machine", () => {
         },
       ];
       const result = flattenTemplateMetrics(metrics) as (UMetric & {
-        templateRef?: string;
+        templateChain?: string[];
         templateInstance?: string;
       })[];
       expect(result).toHaveLength(2);
       expect(result[0].name).toBe("Station1/Pump1/temperature");
-      expect(result[0].templateRef).toBe("Pump_Type");
+      expect(result[0].templateChain).toEqual(["Station_Type", "Pump_Type"]);
       expect(result[0].templateInstance).toBe("Station1");
       expect(result[1].name).toBe("Station1/stationName");
-      expect(result[1].templateRef).toBe("Station_Type");
+      expect(result[1].templateChain).toEqual(["Station_Type"]);
       expect(result[1].templateInstance).toBe("Station1");
     });
 
@@ -383,10 +383,10 @@ describe("The host state machine", () => {
         { name: "temperature", type: "Double", value: 72.5 },
       ];
       const result = flattenTemplateMetrics(metrics) as (UMetric & {
-        templateRef?: string;
+        templateChain?: string[];
         templateInstance?: string;
       })[];
-      expect(result[0].templateRef).toBeUndefined();
+      expect(result[0].templateChain).toBeUndefined();
       expect(result[0].templateInstance).toBeUndefined();
     });
   });

--- a/types.ts
+++ b/types.ts
@@ -337,8 +337,8 @@ export interface SparkplugMetric extends Omit<UMetric, "value"> {
     timestamp: number;
     value: UMetric["value"];
   };
-  /** The name of the template definition this metric was flattened from (e.g., "Pump_Type"). */
-  templateRef?: string;
+  /** Ordered chain of template definition names from outermost to innermost (e.g., ["Motor_Type", "Pump_Type"]). */
+  templateChain?: string[];
   /** The name of the template instance this metric belongs to (e.g., "Pump1"). */
   templateInstance?: string;
 }


### PR DESCRIPTION
## Summary
- Replace `templateRef?: string` with `templateChain?: string[]` on `SparkplugMetric`
- `flattenTemplateMetrics` now accumulates the full chain (outermost→innermost) as it recurses, e.g. `["Motor_Type", "Interlock"]` for a doubly-nested metric
- `templateInstance` (top-level instance name) is unchanged
- All 51 test steps passing

## Why
A single `templateRef` only showed the innermost template type, losing the parent context for nested UDTs. The chain gives consumers the full nesting hierarchy for display and codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)