### PR TITLE
Bump sparkplug-payload to ^1.0.6, release 0.0.97

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "mqtt": "npm:mqtt@^5.10.1",
     "nanoid": "npm:nanoid@^5.1.0",
     "pako": "npm:pako@^2.1.0",
-    "sparkplug-payload": "npm:@joyautomation/sparkplug-payload@^1.0.4",
+    "sparkplug-payload": "npm:@joyautomation/sparkplug-payload@^1.0.6",
     "types": "npm:types@^0.1.1"
   },
   "nodeModulesDir": "auto",


### PR DESCRIPTION
## Summary
- Bumps `@joyautomation/sparkplug-payload` from `^1.0.4` to `^1.0.6`
- Releases synapse as `0.0.97`

## What changed in sparkplug-payload 1.0.6
Fixes `getTemplateParamValue` to handle all Sparkplug B integer types (Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64, DateTime) and protobuf3 zero-default omission. Previously, Int64 parameters (type 4) — such as Ignition's `spIndex` — caused a `throw` that crashed the entire DBIRTH protobuf decode, silently dropping all metrics from the message.

## Test plan
- [ ] CI passes
- [ ] Deploy to a space with Ignition RTU devices that send `spIndex` (Int64) in template parameters — DBIRTH should decode cleanly with no `Invalid Parameter value` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)