### PR TITLE
feat: support Sparkplug B 3.0 STATE topic format

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@joyautomation/synapse",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "description": "Synapse is a tool for creating and managing neural networks.",
   "author": "Joy Automation",
   "license": "Apache-2.0",

--- a/mqtt.ts
+++ b/mqtt.ts
@@ -727,6 +727,16 @@ export const handleMessage = (
         emitter.emit("state", state, primaryHostId);
       },
     },
+    {
+      // Sparkplug B 3.0: spBv1.0/STATE/{hostId} with JSON payload {"online":true,"timestamp":...}
+      condition: ({ topic }) => topic.groupId === "STATE" && !!topic.commandType,
+      action: ({ topic, message }) => {
+        const state = Buffer.from(message).toString();
+        const primaryHostId = topic.commandType;
+        log.info(`spBv1.0 STATE message received for ${primaryHostId}, payload: ${state}`);
+        emitter.emit("state", state, primaryHostId);
+      },
+    },
     ...handleCommands,
     {
       condition: () => true,

--- a/stateMachines/host.ts
+++ b/stateMachines/host.ts
@@ -131,6 +131,7 @@ const setupHostEvents = (host: SparkplugHost) => {
         onError(host),
       ),
       subscribeCurry("STATE/#", { qos: 1 }),
+      subscribeCurry("spBv1.0/STATE/#", { qos: 1 }),
       (mqtt) =>
         pipe(
           mqtt,

--- a/stateMachines/node.ts
+++ b/stateMachines/node.ts
@@ -91,8 +91,9 @@ const onConnect = (node: SparkplugNode) => {
         `${createSpbTopic("NCMD", mqttConfig)}`,
         { qos: 0 }
       )(node.mqtt);
-      // Subscribe to STATE
+      // Subscribe to STATE (legacy and Sparkplug B 3.0)
       subscribeCurry("STATE/#", { qos: 1 })(node.mqtt);
+      subscribeCurry("spBv1.0/STATE/#", { qos: 1 })(node.mqtt);
     }
 
     node.events.emit("connected");
@@ -225,7 +226,8 @@ const setupNodeEvents = (node: SparkplugNode) => {
           qos: 0,
         }
       ),
-      subscribeCurry("STATE/#", { qos: 1 })
+      subscribeCurry("STATE/#", { qos: 1 }),
+      subscribeCurry("spBv1.0/STATE/#", { qos: 1 }),
     );
   }
   on<


### PR DESCRIPTION
## Summary
- Subscribe to `spBv1.0/STATE/#` in addition to legacy `STATE/#` in node and host state machines
- Add handler in `handleMessage` for the new topic format where host ID is in the 3rd path segment (`spBv1.0/STATE/{hostId}`)
- Both legacy plain-string payloads (`ONLINE`/`OFFLINE`) and Sparkplug B 3.0 JSON payloads (`{"online":true,"timestamp":...}`) pass through — tentacle-mqtt's `parseStatePayload()` handles format detection
- Bumps version to 0.0.100

## Test plan
- [x] Existing `mqtt.test.ts` passes
- [ ] Verify legacy `STATE/{hostId}` with `ONLINE`/`OFFLINE` payloads still work
- [ ] Verify `spBv1.0/STATE/{hostId}` with JSON payloads trigger the `"state"` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)